### PR TITLE
Feature/m.lee/login signup fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@react-oauth/google": "^0.12.1",
         "@tanstack/react-query": "^5.51.23",
         "@tanstack/react-query-devtools": "^5.51.23",
+        "jotai": "^2.10.1",
         "material-ui-popup-state": "^5.1.2",
         "next": "14.2.3",
         "query-string": "^9.1.1",
@@ -4184,6 +4185,27 @@
       "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
       "engines": {
         "node": ">= 8.3"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.10.1.tgz",
+      "integrity": "sha512-4FycO+BOTl2auLyF2Chvi6KTDqdsdDDtpaL/WHQMs8f3KS1E3loiUShQzAzFA/sMU5cJ0hz/RT1xum9YbG/zaA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-oauth/google": "^0.12.1",
     "@tanstack/react-query": "^5.51.23",
     "@tanstack/react-query-devtools": "^5.51.23",
+    "jotai": "^2.10.1",
     "material-ui-popup-state": "^5.1.2",
     "next": "14.2.3",
     "query-string": "^9.1.1",

--- a/src/app/ThemeRegistry.tsx
+++ b/src/app/ThemeRegistry.tsx
@@ -3,6 +3,7 @@
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
 import theme from "./theme";
+import { UserProvider } from "@/providers/UserProvider";
 
 export default function ThemeRegistry({
   children,
@@ -11,8 +12,10 @@ export default function ThemeRegistry({
 }) {
   return (
     <ThemeProvider theme={theme}>
-      <CssBaseline />
-      {children}
+      <UserProvider>
+        <CssBaseline />
+        {children}
+      </UserProvider>
     </ThemeProvider>
   );
 }

--- a/src/app/login/loading/layout.tsx
+++ b/src/app/login/loading/layout.tsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const layout = ({ children }: { children: React.ReactNode }) => {
+  return <div> {children}</div>;
+};
+
+export default layout;

--- a/src/app/login/loading/page.tsx
+++ b/src/app/login/loading/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import topuColors from "@/lib/colors";
+import { Box, Stack, Typography } from "@mui/material";
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { fetchUserData } from "@/lib/userData/api";
+import { UserData } from "@/lib/userData/types";
+import { userAtom } from "@/atoms/userAtom";
+import { useAtom } from "jotai";
+
+export default function LoginLoading() {
+  const [, setUserData] = useAtom(userAtom);
+  // const [, login] = useAtom(loginAction);
+  // const [, logout] = useAtom(logoutAction);
+  // const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+
+  const router = useRouter();
+  const {
+    data: userData,
+    isLoading: isUserDataLoading,
+    error: userDataError,
+  } = useQuery<UserData>({
+    queryKey: ["userData"],
+    queryFn: fetchUserData,
+  });
+
+  useEffect(() => {
+    console.log("LoginLoading userData", userData);
+    if (userData && userData.firstLogin === true) {
+      router.push("/signup");
+    } else if (userData && userData.firstLogin === false) {
+      setUserData(userData);
+      router.push("/");
+    }
+  }, [userData]);
+
+  return (
+    <React.Fragment>
+      <Stack
+        sx={{
+          // width: "-webkit-fill-available",
+          // height: "-webkit-fill-available",
+          minHeight: "-webkit-fill-available",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          pt: "100px",
+        }}
+      >
+        <Box
+          sx={{
+            width: "580px",
+            height: "366px",
+            border: `6px solid ${topuColors.pointColor.purpleMain}`,
+            borderRadius: "20px",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          <Box
+            sx={{
+              width: "500px",
+              height: "240px",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "space-between",
+            }}
+          >
+            <Typography fontSize={"30px"} fontWeight={"bold"}>
+              loading・・・
+            </Typography>
+          </Box>
+        </Box>
+      </Stack>
+    </React.Fragment>
+  );
+}

--- a/src/app/recruitments/page.tsx
+++ b/src/app/recruitments/page.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo, useState } from "react";
 import RecruitmentList from "@/component/recruitments/RecruitmentList";
 import { fetchRecruitments } from "@/lib/recruitments/api";
-import { Recruitment } from "@/lib/recruitments/types";
 import {
   Button,
   ButtonGroup,
@@ -36,7 +35,12 @@ const RecruitmentsPage = () => {
     React.useState<string>();
   const [searchInput, setSearchInput] = useState<string>("");
   const [searchWords, setSearchWords] = useState<string>("");
-  const { data, isLoading, error, refetch } = useQuery<Recruitment[]>({
+  const {
+    data: response,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<RecruitmentResponse>({
     queryKey: ["recruitments", stackName],
     queryFn: () =>
       fetchRecruitments({
@@ -74,10 +78,12 @@ const RecruitmentsPage = () => {
 
   // <=========== Start Cards Filter ===========>
   const filteredData = useMemo(() => {
-    if (!data || !Array.isArray(data)) return [];
-    if (activeTab === "ALL") return data;
-    return data.filter((item) => item.recruitmentCategories === activeTab);
-  }, [data, activeTab]);
+    if (!response?.data || !Array.isArray(response.data)) return [];
+    if (activeTab === "ALL") return response.data;
+    return response.data.filter(
+      (item) => item.recruitmentCategory === activeTab
+    );
+  }, [response?.data, activeTab]);
 
   const totalPages = Math.ceil(filteredData.length / ITEMS_PER_PAGE);
   const paginatedData = filteredData.slice(
@@ -97,10 +103,6 @@ const RecruitmentsPage = () => {
     setPage(1); // Reset to first page when changing tabs
   };
   // <=========== End Cards Filter ===========>
-
-  // if (isLoading) return <div>Loading...</div>;
-  // if (error) return <div>An error occurred: {(error as Error).message}</div>;
-  // if (!data || !Array.isArray(data)) return <div>No data available</div>;
 
   return (
     <Stack
@@ -210,7 +212,7 @@ const RecruitmentsPage = () => {
       >
         {isLoading && <div>Loading...</div>}
         {error && <div>An error occurred: {(error as Error).message}</div>}
-        {!data || !Array.isArray(data) ? (
+        {!response?.data ? (
           <div>No data available</div>
         ) : (
           <Stack sx={{ width: "100%" }}>

--- a/src/atoms/userAtom.ts
+++ b/src/atoms/userAtom.ts
@@ -1,0 +1,9 @@
+// atoms/userAtom.ts
+import { atom } from "jotai";
+import { UserData } from "@/lib/userData/types";
+
+// 기본 user atom
+export const userAtom = atom<UserData | null>(null);
+
+// 인증 상태 확인을 위한 derived atom
+export const isAuthenticatedAtom = atom((get) => get(userAtom) !== null);

--- a/src/component/Header.tsx
+++ b/src/component/Header.tsx
@@ -2,31 +2,21 @@
 import { white } from "@/lib/colorConfig";
 import topuColors from "@/lib/colors";
 import { Typography, Stack } from "@mui/material";
-import React, { useEffect } from "react";
+import React from "react";
 import CommonButton from "./elements/CommonButton";
-import { useQuery } from "@tanstack/react-query";
 import { get } from "@/service/requestService";
-import { fetchUserData } from "@/lib/userData/api";
-import { UserData } from "@/lib/userData/types";
-import { useRouter } from "next/navigation";
+import { isAuthenticatedAtom, userAtom } from "@/atoms/userAtom";
+import { useAtom, useAtomValue } from "jotai";
 
 export default function Header() {
-  const router = useRouter();
-  const {
-    data: userData,
-    isLoading: isUserDataLoading,
-    error: userDataError,
-  } = useQuery<UserData>({
-    queryKey: ["userData"],
-    queryFn: fetchUserData,
-  });
+  const [user, setUser] = useAtom(userAtom);
+  const isAuthenticated = useAtomValue(isAuthenticatedAtom);
+  console.log("user?", user);
 
-  console.log("userData", userData);
-  useEffect(() => {
-    if (userData && userData.firstLogin === true) {
-      router.push("/signup");
-    }
-  }, [userData]);
+  const handleLogout = async () => {
+    setUser(null); // 로컬 상태 초기화
+  };
+
   return (
     <>
       <Stack
@@ -110,15 +100,15 @@ export default function Header() {
             marginLeft: "10px",
           }}
         />
-        {userData ? (
+        {isAuthenticated ? (
           <Stack>
             <CommonButton
               text={"ログアウト"}
-              onClick={async () => {
-                await get({
-                  url: `/logout`,
-                });
-              }}
+              onClick={handleLogout} // onClick={async () => {
+              //   await get({
+              //     url: `/logout`,
+              //   });
+              // }}
               size="large"
               sx={{
                 backgroundColor: "rgba(0, 0, 0, 0) !important",

--- a/src/lib/recruitments/api.ts
+++ b/src/lib/recruitments/api.ts
@@ -1,4 +1,3 @@
-import { Recruitment } from "@/lib/recruitments/types";
 import { get } from "@/service/requestService";
 
 export const fetchRecruitments = async (
@@ -23,7 +22,7 @@ export const fetchRecruitments = async (
     searchParams.append("search", params.search);
   }
 
-  return await get<Recruitment[]>({
+  return await get<RecruitmentResponse>({
     url: `/recruitments/query?${searchParams.toString()}`,
   });
 };

--- a/src/lib/recruitments/types.ts
+++ b/src/lib/recruitments/types.ts
@@ -1,33 +1,17 @@
-// 채용 정보 관련 타입 정의
-
-// 개별 채용 정보의 구조 정의
-// export interface Recruitment {
-//   id: string;
-//   recruitmentCategories: string;
-//   techStacks: string[];
-//   recruitmentPositions: string[];
-//   recruitmentDeadline: string;
-//   subject: string;
-// }
-
-export interface Recruitment {
-  id: string;
-  created_at: string;
-  updated_at: string;
-  recruitmentCategories: "STUDY" | "PROJECT" | "READING";
-  progressMethods: "ONLINE" | "OFFLINE" | "ALL";
+interface Recruitment {
+  id: number;
+  userId: number;
+  nickname: string;
+  recruitmentCategory: "STUDY" | "PROJECT" | "READING";
   techStacks: string[];
-  positions: string;
-  numberOfPeople: number;
-  progressPeriod: number;
+  positions: string[];
   recruitmentDeadline: string;
-  contract: string;
   subject: string;
-  content: string;
+  progressMethods: "ONLINE" | "OFFLINE" | "ALL";
+  views: number;
 }
 
-// API 응답의 구조 정의
-export interface RecruitmentResponse {
+interface RecruitmentResponse {
+  count: number;
   data: Recruitment[];
-  error: null | string;
 }

--- a/src/providers/UserProvider.tsx
+++ b/src/providers/UserProvider.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useEffect } from "react";
+import { userAtom } from "../atoms/userAtom";
+import { fetchUserData } from "@/lib/userData/api";
+import { useQuery } from "@tanstack/react-query";
+
+export function UserProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useAtom(userAtom);
+
+  const { data: userData } = useQuery({
+    queryKey: ["userData"],
+    queryFn: fetchUserData,
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    if (userData) {
+      setUser(userData);
+    } else if (user === null) {
+    }
+  }, [userData, setUser]);
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
1. 메인화면 등록글 카드로 안나오는에러 수정
2. 회원등록시 아이디중복등 백엔드에서 받아온 에러메세지를 mui 팝업으로 표시(화면이동x)
3. 구글로그인후 login/loading 페이지로 이동해서 여기서 user체크후 firstLogin이면 회원등록으로, 아니면 메인페이지로 보내고 userData를 전역변수(jotai)에 등록해서 필요한 화면에서 공통으로 userData 관리가능(백엔드수정요망: 구글로그인후 메인화이 아닌 login/loading 페이지로 이동해주세용 ) →이렇게 수정하면 userData를 매번 api호출 안해도 되고 jotai에 등록된 userData를 불러쓰기만하면됨


login/loading에서 하는일은
user체크후 이미 회원등록한 유저면 회원정보를 jotai의 userData에 심어줌
firstLogin 유져면 회원등록으로 보낸뒤에, 회원등록 성공하고 나면 입력한정보를 jotai의 userData를 업뎃해줌
→1 또는 2가 끝난 유저정보는 전역변수userData에 저장되어있어서 userData를 원하는 화면에서 불러오기만하면됨